### PR TITLE
Provide posibility to use model and project.

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "ben@howdy.ai",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.18.0",
     "debug": "^2.6.8",
     "request": "^2.81.0",
     "request-promise": "^4.2.1"

--- a/readme.md
+++ b/readme.md
@@ -12,11 +12,17 @@ Add botkit-rasa as a dependency to your Botkit-bot.
 Enable the middleware:
 
 ```javascript 
-var rasa = require('botkit-rasa')({
-    rasa_uri: "my_rasa_url",//if no url was provided http://localhost:5000 will be used.
-    project: "my_project",//project to use, if no project was provided project won't be used in the request.
-    model: "my_model"//model to use, if no model was provided model won't be used in the request.
-    });
+    var rasa = require('botkit-rasa')({
+        rasa_uri: "my_rasa_url",//if no url was provided http://localhost:5000 will be used.
+        project: "my_project",//project to use, if no project was provided project won't be used in the request.
+        model: "my_model"//model to use, if no model was provided model won't be used in the request.
+        });
+
+    //if you chose to not include the project or the model you should adapt your rasa_uri to include these
+    //mind the 'parse' route in this case.
+   var rasa = require('botkit-rasa')({
+       rasa_uri: "localhost:5000/parse?&model=<model>&project=<project>"
+       });
 
     controller.middleware.receive.use(rasa.receive);
 

--- a/readme.md
+++ b/readme.md
@@ -3,14 +3,33 @@
 This plugin provides Botkit developers a way to use the [rasa NLU](https://rasa.ai/) open source, self hosted natural language API.
 
 
+
+## Setup
+
+Add botkit-rasa as a dependency to your Botkit-bot.
+`npm install botkit-rasa`
+
+Enable the middleware:
+
+```javascript 
+var rasa = require('botkit-rasa')({
+    rasa_uri: "my_rasa_url",//if no url was provided http://localhost:5000 will be used.
+    project: "my_project",//project to use, if no project was provided project won't be used in the request.
+    model: "my_model"//model to use, if no model was provided model won't be used in the request.
+    });
+
+    controller.middleware.receive.use(rasa.receive);
+
+    //Eventually set rasa hears as the standard hears method.
+    controller.changeEars(rasa.hears);
 ```
-var rasa = require('botkit-rasa')({rasa_uri: 'http://localhost:5000'});
-controller.middleware.receive.use(rasa.receive);
-
+Setup a controller to use the hears middleware.
+```javascript
 controller.hears(['my_intent'],'message_received', rasa.hears, function(bot, message) {
-
     console.log('Intent:', message.intent);
     console.log('Entities:', message.entities);    
-
 });
 ```
+
+
+

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -8,7 +8,7 @@ module.exports = config => {
   if (!config.rasa_uri) {    
     config.rasa_uri = 'http://localhost:5000'
   }
-  const instance = axios.create({
+  const rasa = axios.create({
     baseURL: config.rasa_uri
   })
 
@@ -33,7 +33,7 @@ module.exports = config => {
         request.params.project=config.project;
         request.params.model=config.model;
       }
-      axios(request).then(function (response) {
+      rasa(request).then(function (response) {
           debug('Rasa response', response);
           message.intent = response.data.intent;
           message.entities = response.data.entities;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -5,10 +5,12 @@ module.exports = config => {
     config = {}
   }
 
-  if (!config.rasa_uri) {
+  if (!config.rasa_uri) {    
     config.rasa_uri = 'http://localhost:5000'
   }
-
+  const instance = axios.create({
+    baseURL: config.rasa_uri
+  })
 
 
   var middleware = {
@@ -21,17 +23,16 @@ module.exports = config => {
       debug('Sending message to Rasa', message.text)
       var request={
         method: 'get',
-        url: `${config.rasa_uri}/parse`,
         params: {
           q: message.text
         }
       };
-      if (config.project) {
+      
+      if(config.project && config.model){
+        request.url="/parse"  
         request.params.project=config.project;
-      };
-      if (config.model) {
         request.params.model=config.model;
-      };
+      }
       axios(request).then(function (response) {
           debug('Rasa response', response);
           message.intent = response.data.intent;

--- a/src/middleware.js
+++ b/src/middleware.js
@@ -28,18 +28,16 @@ module.exports = config => {
       };
       if (config.project) {
         request.params.project=config.project;
-      }
+      };
       if (config.model) {
         request.params.model=config.model;
-      }
-      axios(request)
-        .then(function (response) {
-          debug('Rasa response', response)
-          message.intent = response.data.intent
-          message.entities = response.data.entities
-          next()
-        })
-        .catch(function (err) {
+      };
+      axios(request).then(function (response) {
+          debug('Rasa response', response);
+          message.intent = response.data.intent;
+          message.entities = response.data.entities;
+          next();
+        }).catch(function (err) {
           debug("Couldn't retrieve response from rasa. Check if your url, project and model are set correctly.",err);
         })
     },


### PR DESCRIPTION
Model and project were not passed to rasa. I included the options and provided a posibility to use an url where all the parameters are filled in. The documentation is adjusted. 
The code is not always backwards compatible, the parse route in the url has been removed and is now only added when a model and a project have been provided. This is because normally if you don't provide a project and model  you should fill in the api endpoint itself and not only the base-url. 